### PR TITLE
Mininet Topo

### DIFF
--- a/mininet/default.py
+++ b/mininet/default.py
@@ -39,4 +39,5 @@ def start():
 
 
 if __name__ == '__main__':
+    """To spin up this mininet topology, simply run this as a normal python script with sudo permissions."""
     start()

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -26,6 +26,9 @@ def start():
     mininet = Mininet(topo)
     mininet.start()
 
+    controller = RemoteController(name='custom_pox', port=6633)
+    controller.start()
+
     command = "python -m SimpleHTTPServer 80 &"
 
     print("Spinning up Default Loadbalancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
@@ -35,7 +38,11 @@ def start():
         h.cmd(command)
         print("{} now running SimpleHTTPServer".format(h))
 
-    CLI(mininet)
+    try:
+        CLI(mininet)
+    finally:
+        mininet.stop()
+        controller.stop()
 
 
 if __name__ == '__main__':

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -24,10 +24,9 @@ def start():
     topo = SingleSwitchTopo(n=size)
 
     mininet = Mininet(topo)
-    mininet.start()
+    controller = RemoteController(name='custom_pox', ip='0.0.0.0', port=6633)
 
-    controller = RemoteController(name='custom_pox', port=6633)
-    controller.start()
+    mininet.start(controller=controller)
 
     command = "python -m SimpleHTTPServer 80 &"
 
@@ -42,7 +41,6 @@ def start():
         CLI(mininet)
     finally:
         mininet.stop()
-        controller.stop()
 
 
 if __name__ == '__main__':

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -1,5 +1,6 @@
 from mininet.topo import Topo
 from mininet.net import Mininet
+from mininet.cli import CLI
 from mininet.node import RemoteController
 
 
@@ -30,6 +31,8 @@ def start():
     for i in range(0, size-1):
         h = mininet.hosts[i]
         h.cmd(command)
+
+    CLI(mininet)
 
 
 if __name__ == '__main__':

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -1,0 +1,20 @@
+from mininet.topo import Topo
+from mininet.net import Mininet
+from mininet.node import RemoteController
+
+
+class SingleSwitchTopo(Topo):
+    """Single switch connected to n hosts."""
+    def build(self, n=2):
+        switch = self.addSwitch('s1')
+
+        # Python's range(N) generates 0..N-1
+        for h in range(n):
+            host = self.addHqost('h%s' % (h + 1))
+            self.addLink(host, switch)
+
+
+def start():
+    topo = SingleSwitchTopo(n=6)
+    mininet = Mininet(topo)
+    mininet.start()

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -2,7 +2,7 @@ from mininet.topo import Topo
 from mininet.net import Mininet
 from mininet.cli import CLI
 from mininet.node import RemoteController
-import argparse
+from argparse import ArgumentParser
 
 
 class SingleSwitchTopo(Topo):
@@ -21,7 +21,7 @@ def start():
     Builds default mininet topology with N nodes. N-1 of those nodes are servers, while 1 is a client, which
     we will use as a traffic generator to test our load balancing algorithms.
     """
-    parser = argparse.ArgumentParser(description='Default Load Balancing Test Mininet Topology')
+    parser = ArgumentParser(description='Default Load Balancing Test Mininet Topology')
     parser.add_argument("-n", type=int, help="number of hosts")
     args = parser.parse_args()
 
@@ -36,7 +36,7 @@ def start():
 
     print("Spinning up Default Load Balancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
 
-    for i in range(0, size-1):
+    for i in range(size-1):
         h = mininet.hosts[i]
         h.cmd(command)
         print("{} now running SimpleHTTPServer".format(h))

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -10,11 +10,27 @@ class SingleSwitchTopo(Topo):
 
         # Python's range(N) generates 0..N-1
         for h in range(n):
-            host = self.addHqost('h%s' % (h + 1))
+            host = self.addHost('h%s' % (h + 1))
             self.addLink(host, switch)
 
 
 def start():
-    topo = SingleSwitchTopo(n=6)
+    """
+    Builds default mininet topology with N nodes. N-1 of those nodes are servers, while 1 is a client, which
+    we will use as a traffic generator to test our load balancing algorithms.
+    """
+    size = 4
+    topo = SingleSwitchTopo(n=size)
+
     mininet = Mininet(topo)
     mininet.start()
+
+    command = "python -m SimpleHTTPServer 80 &"
+
+    for i in range(0, size-1):
+        h = topo.hosts[i]
+        h.cmd(command)
+
+
+if __name__ == '__main__':
+    start()

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -23,10 +23,9 @@ def start():
     size = 4
     topo = SingleSwitchTopo(n=size)
 
-    mininet = Mininet(topo)
     controller = RemoteController(name='custom_pox', ip='0.0.0.0', port=6633)
-
-    mininet.start(controller=controller)
+    mininet = Mininet(topo=topo, controller=controller)
+    mininet.start()
 
     command = "python -m SimpleHTTPServer 80 &"
 

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -2,6 +2,7 @@ from mininet.topo import Topo
 from mininet.net import Mininet
 from mininet.cli import CLI
 from mininet.node import RemoteController
+import argparse
 
 
 class SingleSwitchTopo(Topo):
@@ -20,7 +21,11 @@ def start():
     Builds default mininet topology with N nodes. N-1 of those nodes are servers, while 1 is a client, which
     we will use as a traffic generator to test our load balancing algorithms.
     """
-    size = 4
+    parser = argparse.ArgumentParser(description='Default Load Balancing Test Mininet Topology')
+    parser.add_argument("-n", type=int, help="number of hosts")
+    args = parser.parse_args()
+
+    size = args.n
     topo = SingleSwitchTopo(n=size)
 
     controller = RemoteController(name='custom_pox', ip='0.0.0.0', port=6633)
@@ -29,7 +34,7 @@ def start():
 
     command = "python -m SimpleHTTPServer 80 &"
 
-    print("Spinning up Default Loadbalancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
+    print("Spinning up Default Load Balancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
 
     for i in range(0, size-1):
         h = mininet.hosts[i]

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -28,9 +28,12 @@ def start():
 
     command = "python -m SimpleHTTPServer 80 &"
 
+    print("Spinning up Default Loadbalancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
+
     for i in range(0, size-1):
         h = mininet.hosts[i]
         h.cmd(command)
+        print("{} now running SimpleHTTPServer".format(h))
 
     CLI(mininet)
 

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -28,7 +28,7 @@ def start():
     command = "python -m SimpleHTTPServer 80 &"
 
     for i in range(0, size-1):
-        h = topo.hosts[i]
+        h = mininet.hosts[i]
         h.cmd(command)
 
 

--- a/run.py
+++ b/run.py
@@ -1,0 +1,33 @@
+import os
+import argparse
+
+def main():
+    """Runs pox controller which points to h1,h2, and h3."""
+    ip = '10.0.1.1'
+    parser = argparse.ArgumentParser(description='Command line tool for quickly spinning up POX Controller')
+    parser.add_argument("-n", type=int, help="number of servers")
+    parser.add_argument("-lb", type=str, help="load balancing module")
+    args = parser.parse_args()
+
+    servers = ''
+    numservers = args.n
+    lb_alg = args.lb
+
+    for i in range(0, numservers):
+        servers += '10.0.0.{}'.format(i+1)
+
+        if i != numservers-1:
+            servers += ','
+
+    command = "sudo python pox.py log.level --DEBUG {lb} --ip={ip} --servers={servers}".format(
+        lb=lb_alg,
+        ip=ip,
+        servers=servers
+    )
+
+    print("Running command: {}".format(command))
+    os.system(command)
+
+
+if __name__ == "__main__":
+    main()

--- a/run.py
+++ b/run.py
@@ -1,10 +1,11 @@
 import os
-import argparse
+from argparse import ArgumentParser
+
 
 def main():
     """Runs pox controller which points to h1,h2, and h3."""
     ip = '10.0.1.1'
-    parser = argparse.ArgumentParser(description='Command line tool for quickly spinning up POX Controller')
+    parser = ArgumentParser(description='Command line tool for quickly spinning up POX Controller')
     parser.add_argument("-n", type=int, help="number of servers")
     parser.add_argument("-lb", type=str, help="name of load balancing module")
     args = parser.parse_args()
@@ -13,7 +14,7 @@ def main():
     numservers = args.n
     lb_alg = "misc.loadbalancing.{}".format(args.lb)
 
-    for i in range(0, numservers):
+    for i in range(numservers):
         servers += '10.0.0.{}'.format(i+1)
 
         if i != numservers-1:

--- a/run.py
+++ b/run.py
@@ -6,12 +6,12 @@ def main():
     ip = '10.0.1.1'
     parser = argparse.ArgumentParser(description='Command line tool for quickly spinning up POX Controller')
     parser.add_argument("-n", type=int, help="number of servers")
-    parser.add_argument("-lb", type=str, help="load balancing module")
+    parser.add_argument("-lb", type=str, help="name of load balancing module")
     args = parser.parse_args()
 
     servers = ''
     numservers = args.n
-    lb_alg = args.lb
+    lb_alg = "misc.loadbalancing.{}".format(args.lb)
 
     for i in range(0, numservers):
         servers += '10.0.0.{}'.format(i+1)


### PR DESCRIPTION
Introduces new scripts.
`mininet/default.py`
`run.py`

Run `default.py` using the `sudo python` command to easily spin up a Mininet Test Topology. It takes a CLI argument `-n`, which is the number of hosts on the topology.

e.g. `sudo python mininet/default.py -n 5`

`run.py` quickly spins up the POX controller to point to a load balancing module for n servers.

e.g. `sudo python run.py -n 3 -lb lb_least_connection`