### PR TITLE
Dynamic Handling of Load Table When Servers Go Down/Back Up

### DIFF
--- a/pox/misc/loadbalancing/base/lblc_base.py
+++ b/pox/misc/loadbalancing/base/lblc_base.py
@@ -12,7 +12,8 @@ class lblc_base(iplb_base):
         super(lblc_base, self).__init__(server, first_packet, client_port)
 
         # create dictionary to track how many active connections each server has
-        self.server_load = {k: 0 for k in self.servers}
+        # NOTE: These will now be populated via _handle_packetIn (and potentially depopulated by _do_probe)
+        self.server_load = {}
 
         self.log.debug('server_load initial state: {}'.format(self.server_load))
 


### PR DESCRIPTION
If a server goes down, its entry is deleted from the load table.

When it goes up, its entry is added to the table with a starting value of 0.

This does not handle the case when an entirely new server is spun up, because the controller was never pointed to it in the first place.