### PR TITLE
Renovate

### DIFF
--- a/mininet/default.py
+++ b/mininet/default.py
@@ -28,8 +28,8 @@ def start():
 
     size = args.n
     if not args.s:
-        print("-s not provided. Defaulting to n-1 ({})".format(size-1))
         servs = size - 1
+        print("-s not provided. Defaulting to n-1 ({})".format(servs))
     else:
         servs = args.s
 
@@ -52,7 +52,7 @@ def start():
 
     command = "python -m SimpleHTTPServer 80 &"
 
-    print("Spinning up Default Load Balancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
+    print("Spinning up Default Load Balancing Test Topology with {} total nodes and {} servers.".format(size, servs))
 
     for i in range(servs):
         h = mininet.hosts[i]

--- a/mininet/default.py
+++ b/mininet/default.py
@@ -22,10 +22,28 @@ def start():
     we will use as a traffic generator to test our load balancing algorithms.
     """
     parser = ArgumentParser(description='Default Load Balancing Test Mininet Topology')
-    parser.add_argument("-n", type=int, help="number of hosts")
+    parser.add_argument("-n", type=int, help="number of hosts", required=True)
+    parser.add_argument("-s", type=int, help="number of servers")
     args = parser.parse_args()
 
     size = args.n
+    if not args.s:
+        print("-s not provided. Defaulting to n-1 ({})".format(size-1))
+        servs = size - 1
+    else:
+        servs = args.s
+
+    if size <= 0:
+        raise ValueError("Cannot have negative number of hosts.")
+
+    if servs <= 0:
+        raise ValueError("Cannot have negative number of servers")
+
+    if size < servs:
+        raise ValueError("The number of servers is larger than the total number of hosts! ({} > {})".format(
+            servs, size
+        ))
+
     topo = SingleSwitchTopo(n=size)
 
     controller = RemoteController(name='custom_pox', ip='0.0.0.0', port=6633)
@@ -36,7 +54,7 @@ def start():
 
     print("Spinning up Default Load Balancing Test Topology with {} total nodes and {} servers.".format(size, size-1))
 
-    for i in range(size-1):
+    for i in range(servs):
         h = mininet.hosts[i]
         h.cmd(command)
         print("{} now running SimpleHTTPServer".format(h))

--- a/run.py
+++ b/run.py
@@ -6,8 +6,8 @@ def main():
     """Runs pox controller which points to h1,h2, and h3."""
     ip = '10.0.1.1'
     parser = ArgumentParser(description='Command line tool for quickly spinning up POX Controller')
-    parser.add_argument("-n", type=int, help="number of servers")
-    parser.add_argument("-lb", type=str, help="name of load balancing module")
+    parser.add_argument("-n", type=int, help="number of servers", required=True)
+    parser.add_argument("-lb", type=str, help="name of load balancing module", required=True)
     args = parser.parse_args()
 
     servers = ''


### PR DESCRIPTION
Added optional -s flag to `default.py` so that we can specify a custom number of servers. This also comes with value checks (number of servers can't exceed the number of hosts). Made rest of the flags required.

Made all flags for `run.py` required.

Restored `lb_weighted_least_connection.py`. Somehow got distorted?