### PR TITLE
Class rename

### DIFF
--- a/mininet/doublefire_test.py
+++ b/mininet/doublefire_test.py
@@ -59,7 +59,7 @@ def start():
         h5.cmd("cd pox/misc/loadbalancing/utils")
 
         def run(h):
-            h.cmd("sudo python get_stats.py -s 10.0.1.1 -n {} -d 0".format(num_packets))
+            h.cmd("sudo python purefire.py -s 10.0.1.1 -n {}".format(num_packets))
 
         tg1 = Process(target=run, args=(h4,))
         tg2 = Process(target=run, args=(h5,))

--- a/mininet/mirror_test.py
+++ b/mininet/mirror_test.py
@@ -54,7 +54,7 @@ def start():
         clients = [mininet.hosts[servs+i] for i in range(servs)]
 
         def run(h):
-            h.cmd("sudo python pox/misc/loadbalancing/utils/get_stats.py -s 10.0.1.1 -n {} -d 0".format(num_packets))
+            h.cmd("sudo python pox/misc/loadbalancing/utils/purefire.py -s 10.0.1.1 -n {}".format(num_packets))
 
         processes = [Process(target=run, args=(client,)) for client in clients]
 

--- a/mininet/overload_test.py
+++ b/mininet/overload_test.py
@@ -59,7 +59,7 @@ def start():
         h7 = mininet.hosts[6]
 
         def run(h):
-            h.cmd("sudo python pox/misc/loadbalancing/utils/get_stats.py -s 10.0.1.1 -n {} -d 0".format(num_packets))
+            h.cmd("sudo python pox/misc/loadbalancing/utils/purefire.py -s 10.0.1.1 -n {}".format(num_packets))
 
         tg1 = Process(target=run, args=(h4,))
         tg2 = Process(target=run, args=(h5,))

--- a/pox/misc/loadbalancing/lb_dest_hashing.py
+++ b/pox/misc/loadbalancing/lb_dest_hashing.py
@@ -1,13 +1,13 @@
-from pox.misc.loadbalancing.base.iplb_base import *
+from pox.misc.loadbalancing.base.RoundRobin_base import *
 from threading import Lock
 import random
 NUM_OF_IPS = 3
 
-class iplb(iplb_base):
+class RoundRobin(RoundRobin_base):
 
     def __init__(self, server, first_packet, client_port):
         """Extend the __init__ function with extra fields"""
-        super(iplb, self).__init__(server, first_packet, client_port)
+        super(RoundRobin, self).__init__(server, first_packet, client_port)
 
         # create dictionary to track how much load each server has
         self.server_load = {k: 0 for k in self.servers}
@@ -225,14 +225,14 @@ def launch(ip, servers, dpid=None):
         if _dpid != event.dpid:
             log.warn("Ignoring switch %s", event.connection)
         else:
-            if not core.hasComponent('iplb'):
+            if not core.hasComponent('RoundRobin'):
                 # Need to initialize first...
-                core.registerNew(iplb, event.connection, IPAddr(ip), servers)
+                core.registerNew(RoundRobin, event.connection, IPAddr(ip), servers)
                 log.info("IP Load Balancer Ready.")
             log.info("Load Balancing on %s", event.connection)
 
             # Gross hack
-            core.iplb.con = event.connection
-            event.connection.addListeners(core.iplb)
+            core.RoundRobin.con = event.connection
+            event.connection.addListeners(core.RoundRobin)
 
     core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_dest_hashing.py
+++ b/pox/misc/loadbalancing/lb_dest_hashing.py
@@ -1,13 +1,13 @@
-from pox.misc.loadbalancing.base.RoundRobin_base import *
+from pox.misc.loadbalancing.base.iplb_base import *
 from threading import Lock
 import random
 NUM_OF_IPS = 3
 
-class RoundRobin(RoundRobin_base):
+class DestHash(iplb_base):
 
     def __init__(self, server, first_packet, client_port):
         """Extend the __init__ function with extra fields"""
-        super(RoundRobin, self).__init__(server, first_packet, client_port)
+        super(DestHash, self).__init__(server, first_packet, client_port)
 
         # create dictionary to track how much load each server has
         self.server_load = {k: 0 for k in self.servers}
@@ -225,14 +225,14 @@ def launch(ip, servers, dpid=None):
         if _dpid != event.dpid:
             log.warn("Ignoring switch %s", event.connection)
         else:
-            if not core.hasComponent('RoundRobin'):
+            if not core.hasComponent('DestHash'):
                 # Need to initialize first...
-                core.registerNew(RoundRobin, event.connection, IPAddr(ip), servers)
+                core.registerNew(DestHash, event.connection, IPAddr(ip), servers)
                 log.info("IP Load Balancer Ready.")
             log.info("Load Balancing on %s", event.connection)
 
             # Gross hack
-            core.RoundRobin.con = event.connection
-            event.connection.addListeners(core.RoundRobin)
+            core.DestHash.con = event.connection
+            event.connection.addListeners(core.DestHash)
 
     core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_least_connection.py
+++ b/pox/misc/loadbalancing/lb_least_connection.py
@@ -1,7 +1,7 @@
 from pox.misc.loadbalancing.base.lblc_base import *
 
 
-class iplb(lblc_base):
+class LeastConnection(lblc_base):
 
     def _pick_server(self, key, inport):
         """Applies least connection load balancing algorithm"""
@@ -64,14 +64,14 @@ def launch(ip, servers, dpid=None):
         if _dpid != event.dpid:
             log.warn("Ignoring switch %s", event.connection)
         else:
-            if not core.hasComponent('iplb'):
+            if not core.hasComponent('LeastConnection'):
                 # Need to initialize first...
-                core.registerNew(iplb, event.connection, IPAddr(ip), servers)
+                core.registerNew(LeastConnection, event.connection, IPAddr(ip), servers)
                 log.info("IP Load Balancer Ready.")
             log.info("Load Balancing on %s", event.connection)
 
             # Gross hack
-            core.iplb.con = event.connection
-            event.connection.addListeners(core.iplb)
+            core.LeastConnection.con = event.connection
+            event.connection.addListeners(core.LeastConnection)
 
     core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_round_robin.py
+++ b/pox/misc/loadbalancing/lb_round_robin.py
@@ -1,6 +1,6 @@
 from pox.misc.loadbalancing.base.lblc_base import *
 
-class iplb(lblc_base):
+class RoundRobin(lblc_base):
  
   def _pick_server (self,key,inport):
     log.info('Using Round Robin load balancing algorithm.')
@@ -53,15 +53,15 @@ def launch (ip, servers, dpid = None):
     if _dpid != event.dpid:
       log.warn("Ignoring switch %s", event.connection)
     else:
-      if not core.hasComponent('iplb'):
+      if not core.hasComponent('RoundRobin'):
         # Need to initialize first...
-        core.registerNew(iplb, event.connection, IPAddr(ip), servers)
+        core.registerNew(RoundRobin, event.connection, IPAddr(ip), servers)
         log.info("IP Load Balancer Ready.")
       log.info("Load Balancing on %s", event.connection)
 
       # Gross hack
-      core.iplb.con = event.connection
-      event.connection.addListeners(core.iplb)
+      core.RoundRobin.con = event.connection
+      event.connection.addListeners(core.RoundRobin)
 
 
   core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_round_robin.py
+++ b/pox/misc/loadbalancing/lb_round_robin.py
@@ -1,5 +1,6 @@
 from pox.misc.loadbalancing.base.lblc_base import *
 
+
 class RoundRobin(lblc_base):
  
   def _pick_server (self,key,inport):

--- a/pox/misc/loadbalancing/lb_weighted_least_connection.py
+++ b/pox/misc/loadbalancing/lb_weighted_least_connection.py
@@ -1,11 +1,11 @@
 from pox.misc.loadbalancing.base.lblc_base import *
 
 
-class iplb(lblc_base):
+class WeightedLeastConnection(lblc_base):
 
     def __init__(self, server, first_packet, client_port):
         """Extend the __init__ function with extra fields"""
-        super(iplb, self).__init__(server, first_packet, client_port)
+        super(WeightedLeastConnection, self).__init__(server, first_packet, client_port)
 
         # create dictionary to show each server's weight
         # NOTE: Since each node is virtual, they will all have the same weight 1.
@@ -85,14 +85,14 @@ def launch(ip, servers, dpid=None):
         if _dpid != event.dpid:
             log.warn("Ignoring switch %s", event.connection)
         else:
-            if not core.hasComponent('iplb'):
+            if not core.hasComponent('WeightedLeastConnection'):
                 # Need to initialize first...
-                core.registerNew(iplb, event.connection, IPAddr(ip), servers)
+                core.registerNew(WeightedLeastConnection, event.connection, IPAddr(ip), servers)
                 log.info("IP Load Balancer Ready.")
             log.info("Load Balancing on %s", event.connection)
 
             # Gross hack
-            core.iplb.con = event.connection
-            event.connection.addListeners(core.iplb)
+            core.WeightedLeastConnection.con = event.connection
+            event.connection.addListeners(core.WeightedLeastConnection)
 
     core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_weighted_round_robin.py
+++ b/pox/misc/loadbalancing/lb_weighted_round_robin.py
@@ -1,11 +1,11 @@
 from pox.misc.loadbalancing.base.lblc_base import *
 
 
-class iplb(lblc_base):
+class WeightedLeastConnection(lblc_base):
 
     def __init__(self, server, first_packet, client_port):
         """Extend the __init__ function with extra fields"""
-        super(iplb, self).__init__(server, first_packet, client_port)
+        super(WeightedLeastConnection, self).__init__(server, first_packet, client_port)
 
         # create dictionary to show each server's weight
         # NOTE: Since each node is virtual, they will all have the same weight 1.
@@ -100,14 +100,14 @@ def launch(ip, servers, dpid=None):
         if _dpid != event.dpid:
             log.warn("Ignoring switch %s", event.connection)
         else:
-            if not core.hasComponent('iplb'):
+            if not core.hasComponent('WeightedLeastConnection'):
                 # Need to initialize first...
-                core.registerNew(iplb, event.connection, IPAddr(ip), servers)
+                core.registerNew(WeightedLeastConnection, event.connection, IPAddr(ip), servers)
                 log.info("IP Load Balancer Ready.")
             log.info("Load Balancing on %s", event.connection)
 
             # Gross hack
-            core.iplb.con = event.connection
-            event.connection.addListeners(core.iplb)
+            core.WeightedLeastConnection.con = event.connection
+            event.connection.addListeners(core.WeightedLeastConnection)
 
     core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_weighted_round_robin.py
+++ b/pox/misc/loadbalancing/lb_weighted_round_robin.py
@@ -1,11 +1,11 @@
 from pox.misc.loadbalancing.base.lblc_base import *
 
 
-class WeightedLeastConnection(lblc_base):
+class WeightedRoundRobin(lblc_base):
 
     def __init__(self, server, first_packet, client_port):
         """Extend the __init__ function with extra fields"""
-        super(WeightedLeastConnection, self).__init__(server, first_packet, client_port)
+        super(WeightedRoundRobin, self).__init__(server, first_packet, client_port)
 
         # create dictionary to show each server's weight
         # NOTE: Since each node is virtual, they will all have the same weight 1.
@@ -100,14 +100,14 @@ def launch(ip, servers, dpid=None):
         if _dpid != event.dpid:
             log.warn("Ignoring switch %s", event.connection)
         else:
-            if not core.hasComponent('WeightedLeastConnection'):
+            if not core.hasComponent('WeightedRoundRobin'):
                 # Need to initialize first...
-                core.registerNew(WeightedLeastConnection, event.connection, IPAddr(ip), servers)
+                core.registerNew(WeightedRoundRobin, event.connection, IPAddr(ip), servers)
                 log.info("IP Load Balancer Ready.")
             log.info("Load Balancing on %s", event.connection)
 
             # Gross hack
-            core.WeightedLeastConnection.con = event.connection
-            event.connection.addListeners(core.WeightedLeastConnection)
+            core.WeightedRoundRobin.con = event.connection
+            event.connection.addListeners(core.WeightedRoundRobin)
 
     core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/lb_weighted_round_robin.py
+++ b/pox/misc/loadbalancing/lb_weighted_round_robin.py
@@ -14,32 +14,25 @@ class WeightedRoundRobin(lblc_base):
         self.log.debug('Server Weights: {}'.format(self.server_weight))
 
     def _pick_server (self,key,inport):
-        """Applies weighted least connection load balancing algorithm"""
         self.log.info('Using Weighted Round Robin load balancing algorithm.')
-        self.log.debug("Current Load Counter: {}".format(self.server_load))  # debug
 
         if not bool(self.live_servers):
             self.log.error('Error: No servers are online!')
             return
 
         """
-        Find the server with the least load. If several servers all have the minimum load,
-        pick the one with the highest weight value (most capable of handling the new connection).
+        pick the serer with the highest weight value.
         """
-        min_servers = self.get_minimally_loaded_servers()
+        servers = self.servers
 
         # slice the self.server_weight dictionary to only have minimally loaded servers
-        weight_sliced = {k: v for k, v in self.server_weight.items() if k in min_servers}
+        weight_sliced = {k: v for k, v in self.server_weight.items() if k in servers}
 
-        # pick the server among weight_sliced with the maximum weight
         server = max(weight_sliced, key=weight_sliced.get)
-        self._mutate_server_load(server, 'inc')
-        return server
 
-    def get_minimally_loaded_servers(self):
-        """Returns a list of servers that all have the minimum load"""
-        min_load = min(self.server_load.values())
-        return [serv for serv in self.server_load.keys() if self.server_load[serv] == min_load]
+        self._mutate_server_load(server, 'inc')
+
+        return server
 
 
 # Remember which DPID we're operating on (first one to connect)
@@ -62,9 +55,9 @@ def launch(ip, servers, dpid=None):
 
     def new_pi(self, event):
         if event.dpid == _dpid:
-        
-        
-        
+
+
+
     def launch(ip, servers, dpid=None):
     global _dpid
     if dpid is not None:

--- a/pox/misc/loadbalancing/utils/purefire.py
+++ b/pox/misc/loadbalancing/utils/purefire.py
@@ -1,0 +1,23 @@
+import argparse
+import requests
+
+
+def main(serv, n, v):
+    """Uses requests instead of curl. May be cleaner."""
+    if n < 1:
+        raise ValueError("-n must be a positive value")
+
+    for i in range(args.n):
+        requests.get("http://{}".format(serv))
+        if v:
+            print(i)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Simple TG Script using requests')
+    parser.add_argument("-s", type=str, help="address of server", required=True)
+    parser.add_argument("-n", type=int, help="number of times to send GET request to server", required=True)
+    parser.add_argument('-v', type=bool, help="verbose flag. show output if this is here")
+    args = parser.parse_args()
+
+    main(args.s, args.n, args.v)

--- a/pox/misc/loadbalancing/wlc_rand.py
+++ b/pox/misc/loadbalancing/wlc_rand.py
@@ -1,10 +1,10 @@
-from pox.misc.loadbalancing.lb_weighted_least_connection import WeightedLeastConnection
+from pox.misc.loadbalancing.lb_weighted_least_connection import RandWLC
 
 
-class RandWLC(WeightedLeastConnection):
-    """Variant of WeightedLeastConnection that assigns random weights to servers"""
+class RandWLC(RandWLC):
+    """Variant of RandWLC that assigns random weights to servers"""
     def __init__(self, server, first_packet, client_port):
-        super(WeightedLeastConnection, self).__init__(server, first_packet, client_port)
+        super(RandWLC, self).__init__(server, first_packet, client_port)
         self.server_weight = {k: random.randint(1,5) for k in self.servers}
 
 # Remember which DPID we're operating on (first one to connect)
@@ -12,25 +12,6 @@ _dpid = None
 
 
 def launch(ip, servers, dpid=None):
-    global _dpid
-    if dpid is not None:
-        _dpid = str_to_dpid(dpid)
-
-    servers = servers.replace(",", " ").split()
-    servers = [IPAddr(x) for x in servers]
-    ip = IPAddr(ip)
-
-    # We only want to enable ARP Responder *only* on the load balancer switch,
-    # so we do some disgusting hackery and then boot it up.
-    from proto.arp_responder import ARPResponder
-    old_pi = ARPResponder._handle_PacketIn
-
-    def new_pi(self, event):
-        if event.dpid == _dpid:
-
-
-
-    def launch(ip, servers, dpid=None):
     global _dpid
     if dpid is not None:
         _dpid = str_to_dpid(dpid)

--- a/pox/misc/loadbalancing/wlc_rand.py
+++ b/pox/misc/loadbalancing/wlc_rand.py
@@ -1,3 +1,78 @@
 from pox.misc.loadbalancing.lb_weighted_least_connection import WeightedLeastConnection
 
+
 class RandWLC(WeightedLeastConnection):
+    """Variant of WeightedLeastConnection that assigns random weights to servers"""
+    def __init__(self, server, first_packet, client_port):
+        super(WeightedLeastConnection, self).__init__(server, first_packet, client_port)
+        self.server_weight = {k: random.randint(1,5) for k in self.servers}
+
+# Remember which DPID we're operating on (first one to connect)
+_dpid = None
+
+
+def launch(ip, servers, dpid=None):
+    global _dpid
+    if dpid is not None:
+        _dpid = str_to_dpid(dpid)
+
+    servers = servers.replace(",", " ").split()
+    servers = [IPAddr(x) for x in servers]
+    ip = IPAddr(ip)
+
+    # We only want to enable ARP Responder *only* on the load balancer switch,
+    # so we do some disgusting hackery and then boot it up.
+    from proto.arp_responder import ARPResponder
+    old_pi = ARPResponder._handle_PacketIn
+
+    def new_pi(self, event):
+        if event.dpid == _dpid:
+
+
+
+    def launch(ip, servers, dpid=None):
+    global _dpid
+    if dpid is not None:
+        _dpid = str_to_dpid(dpid)
+
+    servers = servers.replace(",", " ").split()
+    servers = [IPAddr(x) for x in servers]
+    ip = IPAddr(ip)
+
+    # We only want to enable ARP Responder *only* on the load balancer switch,
+    # so we do some disgusting hackery and then boot it up.
+    from proto.arp_responder import ARPResponder
+    old_pi = ARPResponder._handle_PacketIn
+
+    def new_pi(self, event):
+        if event.dpid == _dpid:
+            # Yes, the packet-in is on the right switch
+            return old_pi(self, event)
+
+    ARPResponder._handle_PacketIn = new_pi
+
+    # Hackery done.  Now start it.
+    from proto.arp_responder import launch as arp_launch
+    arp_launch(eat_packets=False, **{str(ip): True})
+    import logging
+    logging.getLogger("proto.arp_responder").setLevel(logging.WARN)
+
+    def _handle_ConnectionUp(event):
+        global _dpid
+        if _dpid is None:
+            _dpid = event.dpid
+
+        if _dpid != event.dpid:
+            log.warn("Ignoring switch %s", event.connection)
+        else:
+            if not core.hasComponent('RandWLC'):
+                # Need to initialize first...
+                core.registerNew(RandWLC, event.connection, IPAddr(ip), servers)
+                log.info("IP Load Balancer Ready.")
+            log.info("Load Balancing on %s", event.connection)
+
+            # Gross hack
+            core.RandWLC.con = event.connection
+            event.connection.addListeners(core.RandWLC)
+
+    core.openflow.addListenerByName("ConnectionUp", _handle_ConnectionUp)

--- a/pox/misc/loadbalancing/wlc_rand.py
+++ b/pox/misc/loadbalancing/wlc_rand.py
@@ -6,7 +6,8 @@ class RandWLC(WeightedLeastConnection):
     """Variant of RandWLC that assigns random weights to servers"""
     def __init__(self, server, first_packet, client_port):
         super(RandWLC, self).__init__(server, first_packet, client_port)
-        self.server_weight = {k: random.randint(1,5) for k in self.servers}
+        self.server_weight = {k: random.randint(1, 5) for k in self.servers}
+        self.log.debug('Randomized Server Weights: {}'.format(self.server_weight))
 
 # Remember which DPID we're operating on (first one to connect)
 _dpid = None

--- a/pox/misc/loadbalancing/wlc_rand.py
+++ b/pox/misc/loadbalancing/wlc_rand.py
@@ -1,0 +1,3 @@
+from pox.misc.loadbalancing.lb_weighted_least_connection import WeightedLeastConnection
+
+class RandWLC(WeightedLeastConnection):

--- a/pox/misc/loadbalancing/wlc_rand.py
+++ b/pox/misc/loadbalancing/wlc_rand.py
@@ -1,4 +1,5 @@
 from pox.misc.loadbalancing.lb_weighted_least_connection import WeightedLeastConnection
+from pox.misc.loadbalancing.base.lblc_base import *
 
 
 class RandWLC(WeightedLeastConnection):

--- a/pox/misc/loadbalancing/wlc_rand.py
+++ b/pox/misc/loadbalancing/wlc_rand.py
@@ -1,7 +1,7 @@
-from pox.misc.loadbalancing.lb_weighted_least_connection import RandWLC
+from pox.misc.loadbalancing.lb_weighted_least_connection import WeightedLeastConnection
 
 
-class RandWLC(RandWLC):
+class RandWLC(WeightedLeastConnection):
     """Variant of RandWLC that assigns random weights to servers"""
     def __init__(self, server, first_packet, client_port):
         super(RandWLC, self).__init__(server, first_packet, client_port)


### PR DESCRIPTION
Accidentally overwrote weighted round robin, so I restored it.

Renamed classes from iplb and the launch functions accordingly.

Added flavor of Weighted Least Connection that has randomized weights for each server (from 1 to 5).

Added purefire.py, a TG that uses requests instead of pycurl.